### PR TITLE
Redo the raft autojoin

### DIFF
--- a/Vault-Deployment/helm-install.tf
+++ b/Vault-Deployment/helm-install.tf
@@ -41,7 +41,7 @@ resource "helm_release" "vault-secrets-operator" {
   chart      = "vault-secrets-operator"
   create_namespace = true
   namespace  = "vault-secrets-operator"
-  version    = "0.1.0-beta"
+  version    = "0.4.0"
   wait      = false
 }
 

--- a/Vault-Deployment/values/vault-values.yaml
+++ b/Vault-Deployment/values/vault-values.yaml
@@ -84,7 +84,7 @@ server:
         listener "tcp" {
           address = "[::]:8200"
           cluster_address = "[::]:8201"
-          #tls_disable = 1
+          # tls_disable = 1
           tls_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.crt"
           tls_key_file  = "/vault/userconfig/vault-ha-tls/vault-playground-cert.key"
           tls_client_ca_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.ca"
@@ -96,24 +96,12 @@ server:
         storage "raft" {
           path = "/vault/data"
           retry_join {
-            leader_api_addr = "https://vault-0.vault-internal:8200"
+            leader_tls_servername = "vault-internal"
+            leader_api_addr = "https://vault-active:8200"
             leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.crt"
             leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.key"
             leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.ca"
           }
-          retry_join {
-            leader_api_addr = "https://vault-1.vault-internal:8200"
-            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.crt"
-            leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.key"
-            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.ca"
-          }
-          retry_join {
-            leader_api_addr = "https://vault-2.vault-internal:8200"
-            leader_client_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.crt"
-            leader_client_key_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.key"
-            leader_ca_cert_file = "/vault/userconfig/vault-ha-tls/vault-playground-cert.ca"
-          }
-
 
           autopilot {
             cleanup_dead_servers = "true"


### PR DESCRIPTION
Raft autojoin endpoint changed to vault-active service to make the Vault pods join the cluster automatically.